### PR TITLE
Deprecated maven utility remove

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
-		<querydsl.version>5.0.0</querydsl.version>
 		<jackson.version>2.16.2</jackson.version>
 	</properties>
 	<dependencies>
@@ -50,28 +49,34 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<!--- Querydsl ## 8.2 Querydsl vulnerable to HQL injection trough orderBy ## -->
+		<!--- Querydsl -->
 		<dependency>
 			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-jpa</artifactId>
-			<version>${querydsl.version}</version>
+			<version>5.1.0</version>
 			<classifier>jakarta</classifier>
 		</dependency>
 		<dependency>
 			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-apt</artifactId>
-			<version>${querydsl.version}</version>
+			<scope>provided</scope>
+			<version>5.1.0</version>
 			<classifier>jakarta</classifier>
 		</dependency>
 		<dependency>
 			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-core</artifactId>
-			<version>${querydsl.version}</version>
+			<version>5.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-sql</artifactId>
-			<version>${querydsl.version}</version>
+			<version>5.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
@@ -113,31 +118,8 @@
 		</dependency>
 
 	</dependencies>
-
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>com.mysema.maven</groupId>
-				<artifactId>apt-maven-plugin</artifactId>
-				<version>1.1.3</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>process</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>target/generated-sources/java</outputDirectory>
-							<processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
-
 </project>


### PR DESCRIPTION
- upgraded com.querydsl version to 2024 5.1.0
- removed maven plugin for querydsl-apt due to it being deprecated for spring boot 3.x reference: 

https://github.com/querydsl/querydsl/issues/3296